### PR TITLE
Wrap header with ifdef for C++ compatibility

### DIFF
--- a/software/libdvi/dvi.h
+++ b/software/libdvi/dvi.h
@@ -1,6 +1,10 @@
 #ifndef _DVI_H
 #define _DVI_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define N_TMDS_LANES 3
 #define TMDS_SYNC_LANE 0 // blue!
 
@@ -68,5 +72,9 @@ void dvi_scanbuf_main_16bpp(struct dvi_inst *inst);
 // Same as above, but each q_colour_valid entry is a framebuffer
 void dvi_framebuf_main_8bpp(struct dvi_inst *inst);
 void dvi_framebuf_main_16bpp(struct dvi_inst *inst);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Was scratching my head there for a bit when the linker didn't find dvi_init.

This seems like a generally useful addition, hence PR.