### PR TITLE
Add 720x480p 60Hz mode (270 MHz bit clock)

### DIFF
--- a/software/apps/colour_terminal/main.c
+++ b/software/apps/colour_terminal/main.c
@@ -27,6 +27,7 @@
 
 // Pick one:
 #define MODE_640x480_60Hz
+// #define MODE_720x480_60Hz
 // #define MODE_800x600_60Hz
 // #define MODE_960x540p_60Hz
 // #define MODE_1280x720_30Hz
@@ -38,13 +39,19 @@
 #define VREG_VSEL VREG_VOLTAGE_1_20
 #define DVI_TIMING dvi_timing_640x480p_60hz
 
+#elif defined(MODE_720x480_60Hz)
+// DVDD 1.2V
+#define FRAME_WIDTH 720
+#define FRAME_HEIGHT 480
+#define VREG_VSEL VREG_VOLTAGE_1_20
+#define DVI_TIMING dvi_timing_720x480p_60hz
+
 #elif defined(MODE_800x600_60Hz)
 // DVDD 1.3V, going downhill with a tailwind
 #define FRAME_WIDTH 800
 #define FRAME_HEIGHT 600
 #define VREG_VSEL VREG_VOLTAGE_1_30
 #define DVI_TIMING dvi_timing_800x600p_60hz
-
 
 #elif defined(MODE_960x540p_60Hz)
 // DVDD 1.25V (slower silicon may need the full 1.3, or just not work)

--- a/software/apps/terminal/main.c
+++ b/software/apps/terminal/main.c
@@ -26,6 +26,7 @@
 
 // Pick one:
 #define MODE_640x480_60Hz
+// #define MODE_720x480_60Hz
 // #define MODE_800x600_60Hz
 // #define MODE_960x540p_60Hz
 // #define MODE_1280x720_30Hz
@@ -37,13 +38,19 @@
 #define VREG_VSEL VREG_VOLTAGE_1_20
 #define DVI_TIMING dvi_timing_640x480p_60hz
 
+#elif defined(MODE_720x480_60Hz)
+// DVDD 1.2V
+#define FRAME_WIDTH 720
+#define FRAME_HEIGHT 480
+#define VREG_VSEL VREG_VOLTAGE_1_20
+#define DVI_TIMING dvi_timing_720x480p_60hz
+
 #elif defined(MODE_800x600_60Hz)
 // DVDD 1.3V, going downhill with a tailwind
 #define FRAME_WIDTH 800
 #define FRAME_HEIGHT 600
 #define VREG_VSEL VREG_VOLTAGE_1_30
 #define DVI_TIMING dvi_timing_800x600p_60hz
-
 
 #elif defined(MODE_960x540p_60Hz)
 // DVDD 1.25V (slower silicon may need the full 1.3, or just not work)

--- a/software/libdvi/dvi_timing.c
+++ b/software/libdvi/dvi_timing.c
@@ -28,6 +28,24 @@ const struct dvi_timing __dvi_const(dvi_timing_640x480p_60hz) = {
 	.bit_clk_khz       = 252000
 };
 
+// 720x480p 60 Hz -- Required by CEA for EDTV/HDTV displays. Convenient for
+// emulating NTSC machines with visible overscan and reasonable clk_sys (270 MHz).
+const struct dvi_timing __dvi_const(dvi_timing_720x480p_60hz) = {
+	.h_sync_polarity   = false,
+	.h_front_porch     = 16,
+	.h_sync_width      = 62,
+	.h_back_porch      = 60,
+	.h_active_pixels   = 720,
+
+	.v_sync_polarity   = false,
+	.v_front_porch     = 9,
+	.v_sync_width      = 6,
+	.v_back_porch      = 30,
+	.v_active_lines    = 480,
+
+	.bit_clk_khz       = 270000
+};
+
 // SVGA -- completely by-the-book but requires 400 MHz clk_sys
 const struct dvi_timing __dvi_const(dvi_timing_800x600p_60hz) = {
 	.h_sync_polarity   = false,

--- a/software/libdvi/dvi_timing.h
+++ b/software/libdvi/dvi_timing.h
@@ -74,6 +74,7 @@ struct dvi_lane_dma_cfg {
 extern const uint32_t dvi_ctrl_syms[4];
 
 extern const struct dvi_timing dvi_timing_640x480p_60hz;
+extern const struct dvi_timing dvi_timing_720x480p_60hz;
 extern const struct dvi_timing dvi_timing_800x480p_60hz;
 extern const struct dvi_timing dvi_timing_800x600p_60hz;
 extern const struct dvi_timing dvi_timing_960x540p_60hz;


### PR DESCRIPTION
This PR adds support for CEA Mode 2, which is a convenient resolution for displaying deinterlaced NTSC video with visible overscan.

I've been using this DVI timing for a while in a [retrocomputing project](https://github.com/DLehenbauer/commodore-pet-clone), and it's worked well for me.  I thought it was worth upstreaming.

Best regards and thank you for sharing your PicoDVI library with the community.  It unlocks a lot of possibilities for the RP2040.
