### PR TITLE
Fix heap corruption with dvi_timing_720x480p_60hz (issue #98)

### DIFF
--- a/software/libdvi/dvi.c
+++ b/software/libdvi/dvi.c
@@ -42,10 +42,25 @@ void dvi_init(struct dvi_inst *inst, uint spinlock_tmds_queue, uint spinlock_col
 
 	for (int i = 0; i < DVI_N_TMDS_BUFFERS; ++i) {
 		void *tmdsbuf;
+
+		// TMDS encoders write output in fixed-size chunks per loop iteration.
+		// We need to align the size of tmdsbuf accordingly to prevent overrun
+		// when the input pixel count is not a multiple of the chunk size.
+		//
+		// Encoder chunk sizes (in pixels):
+		//   - 1bpp:  32 * TMDS_ENCODE_UNROLL
+		//   - 8bpp:   8 * TMDS_ENCODE_UNROLL
+		//   - 16bpp:  4 * TMDS_ENCODE_UNROLL
+		//
+		// We align to 32 * TMDS_ENCODE_UNROLL pixels, which safely covers all
+		// current encoder variants.
+		const uint align_mask = 32 * TMDS_ENCODE_UNROLL - 1;
+		const uint n_pix = (inst->timing->h_active_pixels + align_mask) & ~align_mask;
+
 #if DVI_MONOCHROME_TMDS
-		tmdsbuf = malloc(inst->timing->h_active_pixels / DVI_SYMBOLS_PER_WORD * sizeof(uint32_t));
+		tmdsbuf = malloc(n_pix / DVI_SYMBOLS_PER_WORD * sizeof(uint32_t));
 #else
-		tmdsbuf = malloc(3 * inst->timing->h_active_pixels / DVI_SYMBOLS_PER_WORD * sizeof(uint32_t));
+		tmdsbuf = malloc(N_TMDS_LANES * n_pix / DVI_SYMBOLS_PER_WORD * sizeof(uint32_t));
 #endif
 		if (!tmdsbuf)
 			panic("TMDS buffer allocation failed");


### PR DESCRIPTION
Fixes issue #98.

I noticed heap corruption when using dvi_timing_720x480p_60hz with DVI_MONOCHROME_TMDS. The cause was 'tmds_encode_1bpp()' overrunning the 'tmdsbuf' allocated in 'dvi_init()'.

The problem occurs because 'tmds_encode_1bpp()' processes 32 pixels per loop iteration. Because 720 is not evenly divisible by 32, the final chunk writes past the end of tmdsbuf.

Allocated: 720 / DVI_SYMBOLS_PER_WORD * sizeof(uint32_t) = 720 / 2 * 4 = 1440 bytes
Written: ceil(720 / 32) * 32 symbols * 2 bytes/symbol = 23 * 32 * 2 = 1472 bytes
Overrun: 32 bytes

The proposed fix is to conservatively round h_active_pixels up to the next multiple of 32 * TMDS_ENCODE_UNROLL.  This only affects 'dvi_timing_720x480p_60hz', as the other horizontal resolutions in 'dvi_timing.c' are already multiples of 32.