### PR TITLE
Add Waveshare RP2350-PiZero configuration (Addresses issue #102)

### DIFF
--- a/software/include/common_dvi_pin_configs.h
+++ b/software/include/common_dvi_pin_configs.h
@@ -126,4 +126,13 @@ static const struct dvi_serialiser_cfg olimex_rp2040_cfg = {
     .invert_diffpairs = true
 };
 
+// Waveshare RP2350-PiZero
+static const struct dvi_serialiser_cfg waveshare_rp2350_pizero = {
+    .pio              = pio0,
+    .sm_tmds          = {0, 1, 2},
+    .pins_tmds        = {36, 34, 32},
+    .pins_clk         = 38,
+    .invert_diffpairs = false
+};
+
 #endif

--- a/software/libdvi/dvi_serialiser.pio
+++ b/software/libdvi/dvi_serialiser.pio
@@ -30,8 +30,8 @@
 #include "dvi_config_defs.h"
 
 static inline void dvi_serialiser_program_init(PIO pio, uint sm, uint offset, uint data_pins, bool debug) {
-    pio_sm_set_pins_with_mask(pio, sm, 2u << data_pins, 3u << data_pins);
-    pio_sm_set_pindirs_with_mask(pio, sm, ~0u, 3u << data_pins);
+    pio_sm_set_pins_with_mask64(pio, sm, 2ull << data_pins, 3ull << data_pins);
+    pio_sm_set_pindirs_with_mask64(pio, sm, ~0ull, 3ull << data_pins);
     pio_gpio_init(pio, data_pins);
     pio_gpio_init(pio, data_pins + 1);
 


### PR DESCRIPTION
Adds the pin configuration for Waveshare RP2350-PiZero.

To support these high-numbered pins, dvi_serialiser_program_init is updated to use pio_sm_set_pins_with_mask64 and pio_sm_set_pindirs_with_mask64 instead of their 32-bit counterparts. This change is non-destructive: both functions are available in the Pico SDK for RP2040 and RP2350 alike, and on RP2040 they internally cast to uint32_t — producing identical behaviour for all existing boards whose pins are below 32.


> Note: I only have access to the Waveshare RP2350-PiZero for testing. Confirmation that existing RP2040 and other RP2350 boards are unaffected would be appreciated.